### PR TITLE
Remove call to locationHours as a stopgap measure

### DIFF
--- a/inc/locationHours.php
+++ b/inc/locationHours.php
@@ -1,5 +1,5 @@
 <?php
-
+/*
 	global $blog_id;
 	$current_blog_id = $blog_id;
 
@@ -12,6 +12,7 @@
 
 	$hasHours = hasHours($locationId, date("Y-m-d"));
 	$hoursToday = getHoursToday($locationId);
+	*/
 ?>
 
 	<div class="todayHours">
@@ -20,4 +21,4 @@
 		<span><a href="/hours">See all hours</a></span>
 	</div>
 	
-<?php switch_to_blog($current_blog_id); ?>
+<?php // switch_to_blog($current_blog_id); ?>

--- a/inc/postHead.php
+++ b/inc/postHead.php
@@ -46,7 +46,7 @@
 		<?php 
 			// If doc. services, switch out to main site to get location ids
 			if ($siteName == 'Document Services' && is_front_page()):
-				get_template_part('inc/locationHours');
+				// get_template_part('inc/locationHours');
 			endif;
 
 		?>

--- a/inc/postHead.php
+++ b/inc/postHead.php
@@ -46,7 +46,7 @@
 		<?php 
 			// If doc. services, switch out to main site to get location ids
 			if ($siteName == 'Document Services' && is_front_page()):
-				// get_template_part('inc/locationHours');
+				get_template_part('inc/locationHours');
 			endif;
 
 		?>


### PR DESCRIPTION
This call to locationHours was preventing rendering of the Doc Services
site, so I've removed it temporarily. Most likely this will just need to
be replaced with the markup stub that is populated by the JS hours call.

This change has already been made in production, and will be revisited probably next week as time permits.
